### PR TITLE
feat(dot): add DisablePooling option for DNS over TLS

### DIFF
--- a/pkg/dot/dialer.go
+++ b/pkg/dot/dialer.go
@@ -17,6 +17,7 @@ type Dialer struct {
 	addrPorts           []netip.AddrPort
 	ipv6                bool
 	netDialer           *net.Dialer
+	disablePooling      bool
 	metrics             Metrics
 	randGen             *rand.Rand
 }
@@ -50,8 +51,9 @@ func New(settings Settings) (dial *Dialer, err error) {
 		netDialer: &net.Dialer{
 			Timeout: settings.Timeout,
 		},
-		metrics: settings.Metrics,
-		randGen: rand.New(&mapHashSource{}), //nolint:gosec
+		disablePooling: settings.DisablePooling,
+		metrics:        settings.Metrics,
+		randGen:        rand.New(&mapHashSource{}), //nolint:gosec
 	}, nil
 }
 
@@ -60,9 +62,10 @@ func (d *Dialer) String() string {
 }
 
 // ReusableConnsSupported returns true to indicate that connections created
-// by this dialer can be reused.
+// by this dialer can be reused. Returns false if DisablePooling was set,
+// which forces a new connection for each DNS query.
 func (d *Dialer) ReusableConnsSupported() bool {
-	return true
+	return !d.disablePooling
 }
 
 func (d *Dialer) Addresses() []string {

--- a/pkg/dot/settings.go
+++ b/pkg/dot/settings.go
@@ -29,6 +29,11 @@ type Settings struct {
 	// Metrics is the metrics interface to record metric data.
 	// It defaults to a No-Op metrics implementation.
 	Metrics Metrics
+	// DisablePooling disables connection pooling for DNS over TLS.
+	// When set to true, a new TCP+TLS connection is created for each
+	// DNS query. This can help on systems where TCP connection reuse
+	// causes issues (e.g., older Linux kernels like 4.4.x).
+	DisablePooling bool
 }
 
 func (s *Settings) SetDefaults() {


### PR DESCRIPTION
## Summary

- Add `DisablePooling` field to `dot.Settings` that allows callers to disable connection pooling for DNS over TLS queries
- When `DisablePooling` is true, `ReusableConnsSupported()` returns false, signaling the exchanger to create fresh connections for each query

## Motivation

On systems with older Linux kernels (e.g., Synology NAS devices running kernel 4.4.x), the DNS over TLS connection pooling causes "connection reset by peer" errors and i/o timeouts. This option provides a workaround for affected systems.

Related gluetun issue: https://github.com/qdm12/gluetun/issues/3093

## Changes

- `pkg/dot/settings.go`: Added `DisablePooling bool` field with documentation
- `pkg/dot/dialer.go`: Store `disablePooling` in Dialer struct, return `!d.disablePooling` from `ReusableConnsSupported()`