### PR TITLE
fix(docker): increase healthcheck start-period and retries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN apk --update --no-cache add libcap && \
 FROM scratch
 EXPOSE 53/udp 53/tcp
 ENTRYPOINT ["/entrypoint"]
-HEALTHCHECK --interval=5m --timeout=15s --start-period=5s --retries=1 CMD ["/entrypoint", "healthcheck"]
+HEALTHCHECK --interval=5m --timeout=15s --start-period=30s --retries=2 CMD ["/entrypoint", "healthcheck"]
 USER 1000
 ENV \
     UPSTREAM_TYPE=DoT \


### PR DESCRIPTION
The service startup order is sequential: dns loop, then metrics, then health server. So the health endpoint on :9999 isn't listening until after the block list download finishes. With default filters (malicious + surveillance) that's about 10s on my machine (726k hostnames, 31k IPs, 4.4k CIDRs).

The `start-period` is 5s, which expires before the health server is up. The only allowed retry fails with `connection refused`, and then the container sits as unhealthy for 5 minutes waiting for the next interval check.

In practice this breaks any container that depends on `dns` with `condition: service_healthy`, they all wait 5 minutes on every cold start.

```
# health log from a cold boot, first check hits before :9999 is listening
{"Start":"...T09:27:28...","ExitCode":1,"Output":"ERROR Get \"http://127.0.0.1:9999\": dial tcp 127.0.0.1:9999: connect: connection refused\n"}
{"Start":"...T09:32:29...","ExitCode":0,"Output":""}
```

Changes `start-period` from 5s to 30s and `retries` from 1 to 2. `interval` stays at 5m.