### PR TITLE
pool/renew: bounds-check addrIndex before slice access

### DIFF
--- a/internal/pool/renew.go
+++ b/internal/pool/renew.go
@@ -62,6 +62,17 @@ func (p *Pool) renew(ctx context.Context, conn poolConn, network, reason string)
 	netConn, err := p.dialer.Dial(ctx, network, address)
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
+	if conn.addrIndex >= len(p.addrConns) {
+		// The pool was reconfigured/emptied while we were dialing.
+		// Drop the new conn and report the original error (or a fresh one).
+		if netConn != nil {
+			_ = netConn.Close()
+		}
+		if err == nil {
+			err = fmt.Errorf("pool address index %d out of range", conn.addrIndex)
+		}
+		return poolConn{}, err
+	}
 	addrConns := p.addrConns[conn.addrIndex]
 	p.ensureConnIDToIndex(&addrConns)
 	connIndex, found := addrConns.connIDToIndex[conn.id]


### PR DESCRIPTION
Bounds-check before `p.addrConns[conn.addrIndex]`. Pool reconfiguration during a TLS handshake left `addrConns` shorter than the dialing conn's `addrIndex`; the bare slice access panicked qdm12/gluetun#3292 under DoT connection-reset bursts (Cloudflare DoT `1.0.0.1:853`).